### PR TITLE
fix the windows bat issue.

### DIFF
--- a/bnd2/build.bat
+++ b/bnd2/build.bat
@@ -4,10 +4,12 @@ set GOOS=windows
 set GOARCH=amd64
 go version
 go build -v -o electron/bnd2.exe -ldflags "-s -w -H=windowsgui"
+if "%errorlevel%" == "1" goto :errorend
 
 set GOOS=darwin
 set GOARCH=amd64
 go build -v -o electron/bnd2 -ldflags "-s -w"
+if "%errorlevel%" == "1" goto :errorend
 
 echo Building UI
 cd electron
@@ -15,3 +17,6 @@ node -v
 call npm -v
 call npm install && npm run dist
 cd ..
+
+:errorend
+echo "Error in go build"


### PR DESCRIPTION
fix the windows bat, if the goproxy doesn't work. The go build will interrupt, but the bat still go on. Add the errorlevel to catch the error.

* PR 修复缺陷请先开 issue 报告缺陷
* PR 提交新特性请先到[黑客派](https://hacpai.com)发帖讨论
* PR 请提交到开发分支上
* 我们对编码风格有着较为严格的要求，请在阅读代码后模仿类似风格提交
* 欢迎通过 PR README.md 给我们补充案例
